### PR TITLE
Fixed build errors

### DIFF
--- a/src/sly_1_packer.cpp
+++ b/src/sly_1_packer.cpp
@@ -49,7 +49,7 @@ int main(int argc, char* argv[]) {
 
             wac_entry.type = (WACType)name_str.back();
             wac_entry.name = name_str.substr(0, name_str.size() - ext_size);
-            wac_entry.data = filesystem::file_read(full_path_str);
+            wac_entry.data = filesystem::file_read(std::string_view(full_path_str));
             wac_entry.size = wac_entry.data.size();
             wac_entry.offset = wal_next_sector_offset;
 

--- a/src/sly_compressor.cpp
+++ b/src/sly_compressor.cpp
@@ -70,7 +70,7 @@ int main(int argc, char* argv[]) {
         const std::string output_path = (argc == 3) ? argv[2] : input_path + ".compr";
 
         printf("Opening %s\n", input_path.c_str());
-        const auto input_data = filesystem::file_read(input_path);
+        const auto input_data = filesystem::file_read(std::string_view(input_path));
         const auto input_size = input_data.size();
 
         Buffer output_data;
@@ -114,7 +114,7 @@ int main(int argc, char* argv[]) {
 
         flush_to_output();
 
-        filesystem::file_write(output_path, output_data);
+        filesystem::file_write(std::string_view(output_path), output_data);
 
     } catch (const std::runtime_error& e) {
         printf("Error: %s\n", e.what());

--- a/src/sly_decompressor.cpp
+++ b/src/sly_decompressor.cpp
@@ -16,7 +16,7 @@ int main(int argc, const char** argv) {
     }
 
     const std::string input_filename = argv[1];
-    const auto input_data = filesystem::file_read(input_filename);
+    const auto input_data = filesystem::file_read(std::string_view(input_filename));
     const auto input_size = input_data.size();
 
     char output_data[CHUNK_SIZE*2];


### PR DESCRIPTION
Fixed build errors caused by ambiguous function calls which prevented the sly 1 compressor, decompressor and packer from compiling